### PR TITLE
Related-Bug: #1617070 - Library Upgrades

### DIFF
--- a/webroot/common/ui/js/storage.init.js
+++ b/webroot/common/ui/js/storage.init.js
@@ -12,9 +12,10 @@ define([
     'storage-messages',
     'storage-parsers',
     'storage-view-config',
-    'storage-detail-templates'
-], function (_, Constants, GridConfig, ChartConfig, Labels, Utils, Messages, Parsers, ViewConfig,
-            DetailTemplates) {
+    'storage-detail-templates',
+    'contrail-common'
+], function (_, Constants, GridConfig, ChartConfig, Labels, Utils, Messages, Parsers, ViewConfig, DetailTemplates, Contrail) {
+    contrail = new Contrail();
     swc = new Constants();
     swgc = new GridConfig();
     swcc = new ChartConfig();


### PR DESCRIPTION
- Upgrade to Knockout 3.4.0
- Upgrade to Backbone 1.3.3
- Upgrade to Knockback 1.1.0
- Upgrade to jquery-validation 1.15.1
- Upgrade to jquery.panzoom 3.2.1
- Upgrade to moment 2.14.1
- Upgrade to Handlebars 4.0.5
- Upgrade to Underscore 1.8.3
- Moving bootstrap-sass and node-sass to contrail-webui/common/npm-sources

Change-Id: I2245b400683e4616fc4c9376ef1caa4976740349