### PR TITLE
Require 'chart-utils' as required.

### DIFF
--- a/webroot/monitor/infrastructure/ui/js/views/StorageBarChartInfoView.js
+++ b/webroot/monitor/infrastructure/ui/js/views/StorageBarChartInfoView.js
@@ -4,8 +4,9 @@
 
 define([
     'underscore',
-    'contrail-view'
-],function(_,ContrailView) {
+    'contrail-view',
+    'chart-utils'
+],function(_, ContrailView, chUtils) {
     var BarChartInfoView = ContrailView.extend({
         el: ".chart",
         chart: null,

--- a/webroot/monitor/storage/ui/js/views/ClusterUsageView.js
+++ b/webroot/monitor/storage/ui/js/views/ClusterUsageView.js
@@ -6,8 +6,9 @@ define([
     'underscore',
     'contrail-view',
     'contrail-list-model',
+    'chart-utils',
     'monitor-storage-basedir/js/models/UsageAndStatusDonutChartModel'
-], function (_, ContrailView, ContrailListModel, UsageAndStatusDonutChart) {
+], function (_, ContrailView, ContrailListModel, chUtils, UsageAndStatusDonutChart) {
     var ClusterUsageView = ContrailView.extend({
         el: $(contentContainer),
 


### PR DESCRIPTION
chUtils is no more part of global scope. requiring them as needed.

Change-Id: I10fa230c73937e11ba362415ff05e422fc7b3f6a
Partial-Bug: #1624564